### PR TITLE
Allow subscribing to multiple events like Symfony EventDispatcher does

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "php": ">=5.3.2",
         "symfony/event-dispatcher": "~2.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.*"
+    },
     "autoload": {
         "psr-0": { "Jmikola": "src/" }
     }

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -92,10 +92,14 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     public function addSubscriber(EventSubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
-            if (is_array($params)) {
-                $this->addListener($eventName, array($subscriber, $params[0]), $params[1]);
-            } else {
+            if (is_string($params)) {
                 $this->addListener($eventName, array($subscriber, $params));
+            } elseif (is_string($params[0])) {
+                $this->addListener($eventName, array($subscriber, $params[0]), isset($params[1]) ? $params[1] : 0);
+            } else {
+                foreach ($params as $listener) {
+                    $this->addListener($eventName, array($subscriber, $listener[0]), isset($listener[1]) ? $listener[1] : 0);
+                }
             }
         }
     }
@@ -106,7 +110,13 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     public function removeSubscriber(EventSubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
-            $this->removeListener($eventName, array($subscriber, is_array($params) ? $params[0] : $params));
+            if (is_array($params) && is_array($params[0])) {
+                foreach ($params as $listener) {
+                    $this->removeListener($eventName, array($subscriber, $listener[0]));
+                }
+            } else {
+                $this->removeListener($eventName, array($subscriber, is_string($params) ? $params : $params[0]));
+            }
         }
     }
 


### PR DESCRIPTION
Brings behavior in line with the original Symfony EventDispatcher to allow subscribing multiple listeners to a single event.
