### PR TITLE
Added support for Symfony event-dispatcher v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
-  - hhvm
 
 matrix:
     fast_finish: true
@@ -18,6 +15,14 @@ matrix:
     include:
         - php: 5.3
           env: COMPOSER_FLAGS="--prefer-lowest"
+          dist: precise
+        - php: 7.0
+          before_script:
+            - curl -sSfL -o ~/.phpenv/versions/7.0/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+        - php: hhvm
+          before_script:
+            - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+
 
 before_install:
     - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "^2.3 || ^3.0"
+        "symfony/event-dispatcher": "^2.3 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-0": { "Jmikola": "src/" }


### PR DESCRIPTION
This references issue #10.  

As requested, I created this PR to add support for Symfony v4.  According to the [Symfony changelog](https://github.com/symfony/event-dispatcher/blob/master/CHANGELOG.md), no major API changes were introduced in v4 that should affect this library.