### PR TITLE
Handle preg_quote changes for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 cache:
   directories:


### PR DESCRIPTION
Since PHP 7.3, `preg_quote()` escapes the `#` character. This requires some changes to the search/replace patterns for ListenerPattern's event pattern.

Fixes #13 