### PR TITLE
symfony event dispatcher >= 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -17,10 +13,6 @@ cache:
 
 matrix:
   fast_finish: true
-  include:
-    - php: 5.3
-      dist: precise
-      env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": "^7.2",
         "symfony/event-dispatcher": "^4.3 || ^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "symfony/event-dispatcher": "^2.3 || ^3.0 || ^4.0"
+        "php": ">=7.1.3",
+        "symfony/event-dispatcher": "^4.3 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^6.4"
@@ -20,7 +20,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -2,7 +2,6 @@
 
 namespace Jmikola\WildcardEventDispatcher;
 
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -29,17 +28,17 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::dispatch()
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch(object $event, string $eventName = null): object
     {
         $this->bindPatterns($eventName);
 
-        return $this->dispatcher->dispatch($eventName, $event);
+        return $this->dispatcher->dispatch($event, $eventName);
     }
 
     /**
      * @see EventDispatcherInterface::getListeners()
      */
-    public function getListeners($eventName = null)
+    public function getListeners(string $eventName = null)
     {
         if (null !== $eventName) {
             $this->bindPatterns($eventName);
@@ -61,7 +60,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::hasListeners()
      */
-    public function hasListeners($eventName = null)
+    public function hasListeners(string $eventName = null)
     {
         return (boolean) count($this->getListeners($eventName));
     }
@@ -69,7 +68,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::addListener()
      */
-    public function addListener($eventName, $listener, $priority = 0)
+    public function addListener(string $eventName, $listener, int $priority = 0)
     {
         return $this->hasWildcards($eventName)
             ? $this->addListenerPattern(new ListenerPattern($eventName, $listener, $priority))
@@ -79,7 +78,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::removeListener()
      */
-    public function removeListener($eventName, $listener)
+    public function removeListener(string $eventName, $listener)
     {
         return $this->hasWildcards($eventName)
             ? $this->removeListenerPattern($eventName, $listener)
@@ -201,7 +200,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
      * @throws \InvalidArgumentException if $eventName contains a wildcard pattern
      * @throws \BadMethodCallException if this method is not implemented on the composed EventDispatcher
      */
-    public function getListenerPriority($eventName, $listener)
+    public function getListenerPriority(string $eventName, $listener)
     {
         if ($this->hasWildcards($eventName)) {
             throw new \InvalidArgumentException('Wildcard patterns are not supported');

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherFunctionalTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherFunctionalTest.php
@@ -3,7 +3,7 @@
 namespace Jmikola\Tests\WildcardEventDispatcher;
 
 use Jmikola\WildcardEventDispatcher\WildcardEventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use PHPUnit\Framework\TestCase;
 
 class WildcardEventDispatcherFunctionalTest extends TestCase
@@ -107,10 +107,10 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
         $this->dispatcher->addListener('*.exception', array($this->listener, 'onException'));
         $this->dispatcher->addListener(self::coreRequest, array($this->listener, 'onCoreRequest'));
 
-        $this->dispatcher->dispatch(self::coreRequest);
-        $this->dispatcher->dispatch(self::coreException);
-        $this->dispatcher->dispatch(self::apiRequest);
-        $this->dispatcher->dispatch(self::apiException);
+        $this->dispatcher->dispatch(new Event(), self::coreRequest);
+        $this->dispatcher->dispatch(new Event(), self::coreException);
+        $this->dispatcher->dispatch(new Event(), self::apiRequest);
+        $this->dispatcher->dispatch(new Event(), self::apiException);
 
         $this->assertEquals(4, $this->listener->onAnyInvoked);
         $this->assertEquals(2, $this->listener->onCoreInvoked);

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
@@ -5,6 +5,7 @@ namespace Jmikola\Tests\WildcardEventDispatcher;
 use Jmikola\WildcardEventDispatcher\WildcardEventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class EventDispatcherTest extends TestCase
 {
@@ -58,6 +59,8 @@ class EventDispatcherTest extends TestCase
 
     public function testShouldAddListenersWithWildcardsWhenMatchingEventIsDispatched()
     {
+        $event = new Event();
+
         $this->innerDispatcher->expects($this->once())
             ->id('listener-is-added')
             ->method('addListener')
@@ -66,10 +69,10 @@ class EventDispatcherTest extends TestCase
         $this->innerDispatcher->expects($this->once())
             ->after('listener-is-added')
             ->method('dispatch')
-            ->with('core.request');
+            ->with($event, 'core.request');
 
         $this->dispatcher->addListener('core.*', 'callback', 0);
-        $this->dispatcher->dispatch('core.request');
+        $this->dispatcher->dispatch($event, 'core.request');
     }
 
     public function testShouldAddListenersWithWildcardsWhenListenersForMatchingEventsAreRetrieved()


### PR DESCRIPTION
As of [Symfony 4.3: Simpler event dispatching](https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching)

Adds support for symfony 4.3 and newer, since older versions are unsupported now it should be published with a new major version like v2.0.0

seems like PR #16 is not finished and unchanged since nearly 3 months, so i decided to create a new one...