### PR TITLE
Fix compatibility with Symfony 4.3 and 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ with wildcard syntax inspired by AMQP topic exchanges. Listeners may be bound to
 a wildcard pattern and be notified if a dispatched event's name matches that
 pattern. Literal event name matching is still supported.
 
+Note: the wildcard syntax used by this library is not compatible with the
+[simpler event dispatching][] introduced in Symfony 4.3, which uses the FQCN of
+the event in lieu of a custom string (e.g. `core.request`).
+
 If you are interested in using this library in a Symfony project, you may also
 want to take a look at the corresponding [bundle][].
 
   [Symfony's interface]: https://github.com/symfony/EventDispatcher
+  [simpler event dispatching]: https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
   [bundle]: https://github.com/jmikola/JmikolaWildcardEventDispatcherBundle
 
 ## Installation

--- a/src/Jmikola/WildcardEventDispatcher/LazyListenerPattern.php
+++ b/src/Jmikola/WildcardEventDispatcher/LazyListenerPattern.php
@@ -9,21 +9,19 @@ class LazyListenerPattern extends ListenerPattern
     /**
      * Constructor.
      *
-     * The $listenerProvider argument should be a callback which, when invoked,
-     * returns the listener callback.
+     * The $listenerProvider argument should be a callable which, when invoked,
+     * returns the listener callable.
      *
      * @param string   $eventPattern
-     * @param callback $listenerProvider
+     * @param callable $listenerProvider
      * @param integer  $priority
-     * @throws \InvalidArgumentException if the listener provider is not a callback
      */
-    public function __construct($eventPattern, $listenerProvider, $priority = 0)
+    public function __construct(string $eventPattern, callable $listenerProvider, int $priority = 0)
     {
-        if (!is_callable($listenerProvider)) {
-            throw new \InvalidArgumentException('Listener provider argument must be a callback');
-        }
-
-        parent::__construct($eventPattern, null, $priority);
+        /* Since ListenerPattern requires a callable, we'll use the getListener
+         * method as a placeholder. Later, we can replace it with the actual
+         * listener from the provider callable. */
+        parent::__construct($eventPattern, [$this, 'getListener'], $priority);
 
         $this->listenerProvider = $listenerProvider;
     }
@@ -31,11 +29,11 @@ class LazyListenerPattern extends ListenerPattern
     /**
      * Get the pattern listener, initializing it lazily from its provider.
      *
-     * @return callback
+     * @return callable
      */
-    public function getListener()
+    public function getListener(): callable
     {
-        if (!isset($this->listener) && isset($this->listenerProvider)) {
+        if ($this->listener === [$this, 'getListener']) {
             $this->listener = call_user_func($this->listenerProvider);
             unset($this->listenerProvider);
         }

--- a/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
+++ b/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
@@ -18,10 +18,10 @@ class ListenerPattern
      * Constructor.
      *
      * @param string   $eventPattern
-     * @param callback $listener
+     * @param callable $listener
      * @param integer  $priority
      */
-    public function __construct($eventPattern, $listener, $priority = 0)
+    public function __construct(string $eventPattern, callable $listener, int $priority = 0)
     {
         $this->eventPattern = $eventPattern;
         $this->listener = $listener;
@@ -34,7 +34,7 @@ class ListenerPattern
      *
      * @return string
      */
-    public function getEventPattern()
+    public function getEventPattern(): string
     {
         return $this->eventPattern;
     }
@@ -42,9 +42,9 @@ class ListenerPattern
     /**
      * Get the listener.
      *
-     * @return callback
+     * @return callable
      */
-    public function getListener()
+    public function getListener(): callable
     {
         return $this->listener;
     }
@@ -55,7 +55,7 @@ class ListenerPattern
      * @param EventDispatcherInterface $dispatcher
      * @param string                   $eventName
      */
-    public function bind(EventDispatcherInterface $dispatcher, $eventName)
+    public function bind(EventDispatcherInterface $dispatcher, string $eventName): void
     {
         if (isset($this->events[$eventName])) {
             return;
@@ -71,7 +71,7 @@ class ListenerPattern
      *
      * @param EventDispatcherInterface $dispatcher
      */
-    public function unbind(EventDispatcherInterface $dispatcher)
+    public function unbind(EventDispatcherInterface $dispatcher): void
     {
         foreach ($this->events as $eventName => $_) {
             $dispatcher->removeListener($eventName, $this->getListener());
@@ -86,7 +86,7 @@ class ListenerPattern
      * @param string $eventName
      * @return boolean
      */
-    public final function test($eventName)
+    public final function test(string $eventName): bool
     {
         return (boolean) preg_match($this->regex, $eventName);
     }
@@ -97,7 +97,7 @@ class ListenerPattern
      * @param string $eventPattern
      * @return string
      */
-    private function createRegex($eventPattern)
+    private function createRegex(string $eventPattern): string
     {
         $replacements = self::getReplacements();
 
@@ -113,7 +113,7 @@ class ListenerPattern
      *
      * @return array
      */
-    private static function getReplacements()
+    private static function getReplacements(): array
     {
         if (null !== self::$replacements) {
             return self::$replacements;

--- a/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
+++ b/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
@@ -7,7 +7,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ListenerPattern
 {
     protected $eventPattern;
-    protected $events = array();
+    protected $events = [];
     protected $listener;
     protected $priority;
     protected $regex;
@@ -77,7 +77,7 @@ class ListenerPattern
             $dispatcher->removeListener($eventName, $this->getListener());
         }
 
-        $this->events = array();
+        $this->events = [];
     }
 
     /**
@@ -119,30 +119,30 @@ class ListenerPattern
             return self::$replacements;
         }
 
-        self::$replacements = array(
+        self::$replacements = [
             // Trailing single-wildcard with separator prefix
             '/\\\\\.\\\\\*$/'     => '(?:\.\w+)?',
             // Single-wildcard with separator prefix
             '/\\\\\.\\\\\*/'      => '(?:\.\w+)',
             // Single-wildcard without separator prefix
             '/(?<!\\\\\.)\\\\\*/' => '(?:\w+)',
-        );
+        ];
 
         // preg_quote() escapes `#` in PHP 7.3+
         if (PHP_VERSION_ID >= 70300) {
-            self::$replacements += array(
+            self::$replacements += [
                 // Multi-wildcard with separator prefix
                 '/\\\\\.\\\\\#/'      => '(?:\.\w+)*',
                 // Multi-wildcard without separator prefix
                 '/(?<!\\\\\.)\\\\\#/' => '(?:|\w+(?:\.\w+)*)',
-            );
+            ];
         } else {
-            self::$replacements += array(
+            self::$replacements += [
                 // Multi-wildcard with separator prefix
                 '/\\\\\.#/'      => '(?:\.\w+)*',
                 // Multi-wildcard without separator prefix
                 '/(?<!\\\\\.)#/' => '(?:|\w+(?:\.\w+)*)',
-            );
+            ];
         }
 
         return self::$replacements;

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -9,8 +9,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class WildcardEventDispatcher implements EventDispatcherInterface
 {
     private $dispatcher;
-    private $patterns = array();
-    private $syncedEvents = array();
+    private $patterns = [];
+    private $syncedEvents = [];
 
     /**
      * Constructor.
@@ -92,12 +92,12 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (is_string($params)) {
-                $this->addListener($eventName, array($subscriber, $params));
+                $this->addListener($eventName, [$subscriber, $params]);
             } elseif (is_string($params[0])) {
-                $this->addListener($eventName, array($subscriber, $params[0]), isset($params[1]) ? $params[1] : 0);
+                $this->addListener($eventName, [$subscriber, $params[0]], $params[1] ?? 0);
             } else {
                 foreach ($params as $listener) {
-                    $this->addListener($eventName, array($subscriber, $listener[0]), isset($listener[1]) ? $listener[1] : 0);
+                    $this->addListener($eventName, [$subscriber, $listener[0]], $listener[1] ?? 0);
                 }
             }
         }
@@ -111,10 +111,10 @@ class WildcardEventDispatcher implements EventDispatcherInterface
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (is_array($params) && is_array($params[0])) {
                 foreach ($params as $listener) {
-                    $this->removeListener($eventName, array($subscriber, $listener[0]));
+                    $this->removeListener($eventName, [$subscriber, $listener[0]]);
                 }
             } else {
-                $this->removeListener($eventName, array($subscriber, is_string($params) ? $params : $params[0]));
+                $this->removeListener($eventName, [$subscriber, is_string($params) ? $params : $params[0]]);
             }
         }
     }

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -31,7 +31,13 @@ class WildcardEventDispatcher implements EventDispatcherInterface
      */
     public function dispatch($event, string $eventName = null): object
     {
-        $this->bindPatterns($eventName);
+        /* The event object's FQCN is used in lieu of an event name; however, it
+         * is not compatible with the wildcard syntax used by this library. As
+         * such, there is no reason to attempt to bind the FQCN to any
+         * registered patterns. */
+        if (null !== $eventName) {
+            $this->bindPatterns($eventName);
+        }
 
         return $this->dispatcher->dispatch($event, $eventName);
     }

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -5,6 +5,7 @@ namespace Jmikola\WildcardEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use InvalidArgumentException;
 
 class WildcardEventDispatcher implements EventDispatcherInterface
 {
@@ -28,7 +29,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::dispatch()
      */
-    public function dispatch(object $event, string $eventName = null): object
+    public function dispatch($event, string $eventName = null): object
     {
         $this->bindPatterns($eventName);
 
@@ -38,7 +39,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::getListeners()
      */
-    public function getListeners(string $eventName = null)
+    public function getListeners($eventName = null)
     {
         if (null !== $eventName) {
             $this->bindPatterns($eventName);
@@ -60,7 +61,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::hasListeners()
      */
-    public function hasListeners(string $eventName = null)
+    public function hasListeners($eventName = null)
     {
         return (boolean) count($this->getListeners($eventName));
     }
@@ -68,7 +69,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::addListener()
      */
-    public function addListener(string $eventName, $listener, int $priority = 0)
+    public function addListener($eventName, $listener, $priority = 0)
     {
         return $this->hasWildcards($eventName)
             ? $this->addListenerPattern(new ListenerPattern($eventName, $listener, $priority))
@@ -78,7 +79,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::removeListener()
      */
-    public function removeListener(string $eventName, $listener)
+    public function removeListener($eventName, $listener)
     {
         return $this->hasWildcards($eventName)
             ? $this->removeListenerPattern($eventName, $listener)
@@ -197,17 +198,12 @@ class WildcardEventDispatcher implements EventDispatcherInterface
 
     /**
      * @see EventDispatcherInterface::getListenerPriority()
-     * @throws \InvalidArgumentException if $eventName contains a wildcard pattern
-     * @throws \BadMethodCallException if this method is not implemented on the composed EventDispatcher
+     * @throws InvalidArgumentException if $eventName contains a wildcard pattern
      */
-    public function getListenerPriority(string $eventName, $listener)
+    public function getListenerPriority($eventName, $listener)
     {
         if ($this->hasWildcards($eventName)) {
-            throw new \InvalidArgumentException('Wildcard patterns are not supported');
-        }
-
-        if ( ! method_exists($this->dispatcher, 'getListenerPriority')) {
-            throw new \BadMethodCallException('getListenerPriority() is not implemented');
+            throw new InvalidArgumentException('Wildcard patterns are not supported');
         }
 
         return $this->dispatcher->getListenerPriority($eventName, $listener);

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/LazyListenerPatternTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/LazyListenerPatternTest.php
@@ -4,31 +4,25 @@ namespace Jmikola\Tests\WildcardEventDispatcher;
 
 use Jmikola\WildcardEventDispatcher\LazyListenerPattern;
 use PHPUnit\Framework\TestCase;
-use InvalidArgumentException;
 
 class LazyListenerPatternTest extends TestCase
 {
-    public function testConstructorRequiresListenerProviderCallback()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new LazyListenerPattern('*', null);
-    }
-
     public function testLazyListenerInitialization()
     {
         $listenerProviderInvoked = 0;
+        $listener = function() {};
 
-        $listenerProvider = function() use (&$listenerProviderInvoked) {
+        $listenerProvider = function() use (&$listenerProviderInvoked, $listener) {
             ++$listenerProviderInvoked;
-            return 'callback';
+            return $listener;
         };
 
         $pattern = new LazyListenerPattern('*', $listenerProvider);
 
         $this->assertEquals(0, $listenerProviderInvoked, 'The listener provider should not be invoked until the listener is requested');
-        $this->assertEquals('callback', $pattern->getListener());
+        $this->assertSame($listener, $pattern->getListener());
         $this->assertEquals(1, $listenerProviderInvoked, 'The listener provider should be invoked when the listener is requested');
-        $this->assertEquals('callback', $pattern->getListener());
+        $this->assertSame($listener, $pattern->getListener());
         $this->assertEquals(1, $listenerProviderInvoked, 'The listener provider should only be invoked once');
     }
 }

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/ListenerPatternTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/ListenerPatternTest.php
@@ -25,48 +25,48 @@ class ListenerPatternTest extends TestCase
 
     public function providePatternsAndMatches()
     {
-        return array(
-            array(
+        return [
+            [
                 '*',
-                array('core', 'api', 'v2'),
-                array('', 'core.request'),
-            ),
-            array(
+                ['core', 'api', 'v2'],
+                ['', 'core.request'],
+            ],
+            [
                 '*.exception',
-                array('core.exception', 'api.exception'),
-                array('core', 'api.exception.internal'),
-            ),
-            array(
+                ['core.exception', 'api.exception'],
+                ['core', 'api.exception.internal'],
+            ],
+            [
                 'core.*',
-                array('core', 'core.request', 'core.v2'),
-                array('api', 'core.exception.internal'),
-            ),
-            array(
+                ['core', 'core.request', 'core.v2'],
+                ['api', 'core.exception.internal'],
+            ],
+            [
                 'api.*.*',
-                array('api.exception', 'api.exception.internal'),
-                array('api', 'core'),
-            ),
-            array(
+                ['api.exception', 'api.exception.internal'],
+                ['api', 'core'],
+            ],
+            [
                 '#',
-                array('core', 'core.request', 'api.exception.internal', 'api.v2'),
-                array(),
-            ),
-            array(
+                ['core', 'core.request', 'api.exception.internal', 'api.v2'],
+                [],
+            ],
+            [
                 'api.#.created',
-                array('api.created', 'api.user.created', 'api.v2.user.created'),
-                array('core.created', 'core.user.created', 'core.api.user.created'),
-            ),
-            array(
+                ['api.created', 'api.user.created', 'api.v2.user.created'],
+                ['core.created', 'core.user.created', 'core.api.user.created'],
+            ],
+            [
                 'api.*.cms.#',
-                array('api.v2.cms', 'api.v2.cms.post', 'api.v2.cms.post.created'),
-                array('api.v2', 'core.request.cms'),
-            ),
-            array(
+                ['api.v2.cms', 'api.v2.cms.post', 'api.v2.cms.post.created'],
+                ['api.v2', 'core.request.cms'],
+            ],
+            [
                 'api.#.post.*',
-                array('api.post', 'api.post.created', 'api.v2.cms.post.created'),
-                array('api', 'api.user', 'core.api.post.created'),
-            ),
-        );
+                ['api.post', 'api.post.created', 'api.v2.cms.post.created'],
+                ['api', 'api.user', 'core.api.post.created'],
+            ],
+        ];
     }
 
     public function testDispatcherBinding()

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/ListenerPatternTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/ListenerPatternTest.php
@@ -12,7 +12,7 @@ class ListenerPatternTest extends TestCase
      */
     public function testPatternMatching($eventPattern, array $expectedMatches, array $expectedMisses)
     {
-        $pattern = new ListenerPattern($eventPattern, null);
+        $pattern = new ListenerPattern($eventPattern, function() {});
 
         foreach ($expectedMatches as $eventName) {
             $this->assertTrue($pattern->test($eventName), sprintf('Pattern "%s" should match event "%s"', $eventPattern, $eventName));
@@ -71,7 +71,9 @@ class ListenerPatternTest extends TestCase
 
     public function testDispatcherBinding()
     {
-        $pattern = new ListenerPattern('core.*', $listener = 'callback', $priority = 0);
+        $listener = function() {};
+        $priority = 0;
+        $pattern = new ListenerPattern('core.*', $listener, $priority);
 
         $dispatcher = $this->getMockEventDispatcher();
 

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherFunctionalTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherFunctionalTest.php
@@ -24,7 +24,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
 
     public function testInitialState()
     {
-        $this->assertEquals(array(), $this->dispatcher->getListeners());
+        $this->assertEquals([], $this->dispatcher->getListeners());
         $this->assertFalse($this->dispatcher->hasListeners(self::coreRequest));
         $this->assertFalse($this->dispatcher->hasListeners(self::coreException));
         $this->assertFalse($this->dispatcher->hasListeners(self::apiRequest));
@@ -33,10 +33,10 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
 
     public function testAddingAndRemovingListeners()
     {
-        $this->dispatcher->addListener('#', array($this->listener, 'onAny'));
-        $this->dispatcher->addListener('core.*', array($this->listener, 'onCore'));
-        $this->dispatcher->addListener('*.exception', array($this->listener, 'onException'));
-        $this->dispatcher->addListener(self::coreRequest, array($this->listener, 'onCoreRequest'));
+        $this->dispatcher->addListener('#', [$this->listener, 'onAny']);
+        $this->dispatcher->addListener('core.*', [$this->listener, 'onCore']);
+        $this->dispatcher->addListener('*.exception', [$this->listener, 'onException']);
+        $this->dispatcher->addListener(self::coreRequest, [$this->listener, 'onCoreRequest']);
 
         $this->assertNumberListenersAdded(3, self::coreRequest);
         $this->assertNumberListenersAdded(3, self::coreException);
@@ -44,7 +44,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
         $this->assertNumberListenersAdded(2, self::apiException);
         $this->assertNumberListenersAdded(9);
 
-        $this->dispatcher->removeListener('#', array($this->listener, 'onAny'));
+        $this->dispatcher->removeListener('#', [$this->listener, 'onAny']);
 
         $this->assertNumberListenersAdded(2, self::coreRequest);
         $this->assertNumberListenersAdded(2, self::coreException);
@@ -52,7 +52,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
         $this->assertNumberListenersAdded(1, self::apiException);
         $this->assertNumberListenersAdded(5);
 
-        $this->dispatcher->removeListener('core.*', array($this->listener, 'onCore'));
+        $this->dispatcher->removeListener('core.*', [$this->listener, 'onCore']);
 
         $this->assertNumberListenersAdded(1, self::coreRequest);
         $this->assertNumberListenersAdded(1, self::coreException);
@@ -60,7 +60,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
         $this->assertNumberListenersAdded(1, self::apiException);
         $this->assertNumberListenersAdded(3);
 
-        $this->dispatcher->removeListener('*.exception', array($this->listener, 'onException'));
+        $this->dispatcher->removeListener('*.exception', [$this->listener, 'onException']);
 
         $this->assertNumberListenersAdded(1, self::coreRequest);
         $this->assertNumberListenersAdded(0, self::coreException);
@@ -68,7 +68,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
         $this->assertNumberListenersAdded(0, self::apiException);
         $this->assertNumberListenersAdded(1);
 
-        $this->dispatcher->removeListener(self::coreRequest, array($this->listener, 'onCoreRequest'));
+        $this->dispatcher->removeListener(self::coreRequest, [$this->listener, 'onCoreRequest']);
 
         $this->assertNumberListenersAdded(0, self::coreRequest);
         $this->assertNumberListenersAdded(0, self::coreException);
@@ -79,7 +79,7 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
 
     public function testAddedListenersWithWildcardsAreRegisteredLazily()
     {
-        $this->dispatcher->addListener('#', array($this->listener, 'onAny'));
+        $this->dispatcher->addListener('#', [$this->listener, 'onAny']);
 
         $this->assertNumberListenersAdded(0);
 
@@ -102,10 +102,10 @@ class WildcardEventDispatcherFunctionalTest extends TestCase
 
     public function testDispatch()
     {
-        $this->dispatcher->addListener('#', array($this->listener, 'onAny'));
-        $this->dispatcher->addListener('core.*', array($this->listener, 'onCore'));
-        $this->dispatcher->addListener('*.exception', array($this->listener, 'onException'));
-        $this->dispatcher->addListener(self::coreRequest, array($this->listener, 'onCoreRequest'));
+        $this->dispatcher->addListener('#', [$this->listener, 'onAny']);
+        $this->dispatcher->addListener('core.*', [$this->listener, 'onCore']);
+        $this->dispatcher->addListener('*.exception', [$this->listener, 'onException']);
+        $this->dispatcher->addListener(self::coreRequest, [$this->listener, 'onCoreRequest']);
 
         $this->dispatcher->dispatch(new Event(), self::coreRequest);
         $this->dispatcher->dispatch(new Event(), self::coreException);

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
@@ -33,10 +33,10 @@ class EventDispatcherTest extends TestCase
 
     public function provideListenersWithoutWildcards()
     {
-        return array(
-            array('core.request', 'callback', 0),
-            array('core.exception', array('class', 'method'), 5),
-        );
+        return [
+            ['core.request', function() {}, 0],
+            ['core.exception', function() {}, 5],
+        ];
     }
 
     /**
@@ -52,10 +52,10 @@ class EventDispatcherTest extends TestCase
 
     public function provideListenersWithWildcards()
     {
-        return array(
-            array('core.*', 'callback', 0),
-            array('#', array('class', 'method'), -10),
-        );
+        return [
+            ['core.*', function() {}, 0],
+            ['#', function() {}, -10],
+        ];
     }
 
     public function testShouldAddListenersWithWildcardsWhenMatchingEventIsDispatched()
@@ -107,10 +107,10 @@ class EventDispatcherTest extends TestCase
 
         $this->innerDispatcher->expects($this->any())
             ->method('getListeners')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $this->dispatcher->addListener('core.*', 'callback', 0);
-        $this->assertEquals(array(), $this->dispatcher->getListeners());
+        $this->assertEquals([], $this->dispatcher->getListeners());
     }
 
     public function testAddingAndRemovingAnEventSubscriber()
@@ -122,29 +122,29 @@ class EventDispatcherTest extends TestCase
 
         $this->innerDispatcher->expects($this->at(0))
             ->method('addListener')
-            ->with('core.request', array($subscriber, 'onRequest'), 0);
+            ->with('core.request', [$subscriber, 'onRequest'], 0);
         $this->innerDispatcher->expects($this->at(1))
             ->method('addListener')
-            ->with('core.exception', array($subscriber, 'onException'), 10);
+            ->with('core.exception', [$subscriber, 'onException'], 10);
         $this->innerDispatcher->expects($this->at(2))
             ->method('addListener')
-            ->with('core.multi', array($subscriber, 'onMulti1'), 10);
+            ->with('core.multi', [$subscriber, 'onMulti1'], 10);
         $this->innerDispatcher->expects($this->at(3))
             ->method('addListener')
-            ->with('core.multi', array($subscriber, 'onMulti2'), 20);
+            ->with('core.multi', [$subscriber, 'onMulti2'], 20);
 
         $this->innerDispatcher->expects($this->at(4))
             ->method('removeListener')
-            ->with('core.request', array($subscriber, 'onRequest'));
+            ->with('core.request', [$subscriber, 'onRequest']);
         $this->innerDispatcher->expects($this->at(5))
             ->method('removeListener')
-            ->with('core.exception', array($subscriber, 'onException'));
+            ->with('core.exception', [$subscriber, 'onException']);
         $this->innerDispatcher->expects($this->at(6))
             ->method('removeListener')
-            ->with('core.multi', array($subscriber, 'onMulti1'));
+            ->with('core.multi', [$subscriber, 'onMulti1']);
         $this->innerDispatcher->expects($this->at(7))
             ->method('removeListener')
-            ->with('core.multi', array($subscriber, 'onMulti2'));
+            ->with('core.multi', [$subscriber, 'onMulti2']);
 
 
         $this->dispatcher->addSubscriber($subscriber);
@@ -177,10 +177,10 @@ class TestEventSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             'core.request' => 'onRequest',
-            'core.exception' => array('onException', 10),
-            'core.multi' => array(array('onMulti1', 10), array('onMulti2', 20)),
-        );
+            'core.exception' => ['onException', 10],
+            'core.multi' => [['onMulti1', 10], ['onMulti2', 20]],
+        ];
     }
 }


### PR DESCRIPTION
@Nogrod, @stan220: I think this covers some other things missed by your previous PRs (#16 and #17), which I found when adding `--prefer-lowest` to the CI build to ensure Symfony 4.3 was also tested. I'd appreciate a quick review if you have the time, but if not I can merge and tag without.