### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2 <8.3",
         "symfony/event-dispatcher": "^4.3 || ^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": ">=7.2 <8.3",
+        "php": "^7.2 || ^8.0",
         "symfony/event-dispatcher": "^4.3 || ^5.0"
     },
     "require-dev": {

--- a/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
+++ b/src/Jmikola/WildcardEventDispatcher/ListenerPattern.php
@@ -84,11 +84,11 @@ class ListenerPattern
      * Tests if this pattern matches and event name.
      *
      * @param string $eventName
-     * @return boolean
+     * @return bool
      */
     public final function test(string $eventName): bool
     {
-        return (boolean) preg_match($this->regex, $eventName);
+        return (bool) preg_match($this->regex, $eventName);
     }
 
     /**

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -69,7 +69,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
      */
     public function hasListeners($eventName = null)
     {
-        return (boolean) count($this->getListeners($eventName));
+        return (bool) count($this->getListeners($eventName));
     }
 
     /**
@@ -130,7 +130,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
      * Checks whether a string contains any wildcard characters.
      *
      * @param string $subject
-     * @return boolean
+     * @return bool
      */
     protected function hasWildcards($subject)
     {

--- a/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
+++ b/tests/Jmikola/Tests/WildcardEventDispatcher/WildcardEventDispatcherTest.php
@@ -191,4 +191,7 @@ class TestEventSubscriber implements EventSubscriberInterface
             'core.multi' => [['onMulti1', 10], ['onMulti2', 20]],
         ];
     }
+
+    #[\ReturnTypeWillChange]
+    public function __call(string $name, array $arguments) {}
 }


### PR DESCRIPTION
Fixes #20

- Replace boolean alias with bool type
- Fix failing test `testAddingAndRemovingAnEventSubscriber`
- Mark PHP support up to 8.2