### PR TITLE
Make implicit nullable parameters explicit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
+++ b/src/Jmikola/WildcardEventDispatcher/WildcardEventDispatcher.php
@@ -21,7 +21,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
      *
      * @param EventDispatcherInterface $dispatcher
      */
-    public function __construct(EventDispatcherInterface $dispatcher = null)
+    public function __construct(?EventDispatcherInterface $dispatcher = null)
     {
         $this->dispatcher = $dispatcher ?: new EventDispatcher();
     }
@@ -29,7 +29,7 @@ class WildcardEventDispatcher implements EventDispatcherInterface
     /**
      * @see EventDispatcherInterface::dispatch()
      */
-    public function dispatch($event, string $eventName = null): object
+    public function dispatch($event, ?string $eventName = null): object
     {
         /* The event object's FQCN is used in lieu of an event name; however, it
          * is not compatible with the wildcard syntax used by this library. As


### PR DESCRIPTION
This is needed to support PHP 8.4: https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter